### PR TITLE
Remove unnecessary await from updateLanguageSettings call

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -311,7 +311,7 @@ function getLocaleByObsidianLanguage(lang: string): LocaleStrings {
 	
 	async onload() {
 		await this.loadSettings();
-		await this.updateLanguageSettings();
+		this.updateLanguageSettings();
 		this.addSettingTab(new BlueskySettingTab(this.app, this));
 
 		// 投稿用コマンド登録（コマンドパレット表示 & デフォルトホットキー）


### PR DESCRIPTION
The updateLanguageSettings() method is synchronous and doesn't return a Promise, so the await keyword is not needed. This fixes the ObsidianReviewBot issue: "Unexpected await of a non-Promise (non-Thenable) value."