### PR TITLE
Remove await from updateLanguageSettings call

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -311,7 +311,7 @@ function getLocaleByObsidianLanguage(lang: string): LocaleStrings {
 	
 	async onload() {
 		await this.loadSettings();
-		await this.updateLanguageSettings();
+		this.updateLanguageSettings();
 		this.addSettingTab(new BlueskySettingTab(this.app, this));
 
 		// 投稿用コマンド登録（コマンドパレット表示 & デフォルトホットキー）


### PR DESCRIPTION
## Summary
Changed the `updateLanguageSettings()` method call to be non-blocking by removing the `await` keyword during plugin initialization.

## Changes
- Removed `await` from `this.updateLanguageSettings()` in the `onload()` method
- The method is now called without waiting for it to complete, allowing the plugin initialization to continue immediately

## Details
This change allows the plugin to finish loading without being blocked by the language settings update. Since the language settings update doesn't appear to be critical for the initial plugin load sequence, making it non-blocking improves the plugin's startup performance.

https://claude.ai/code/session_01FW7zdtneuCfAH7cN2iy57A